### PR TITLE
Fixing enabling submit button when using jQuery Mobile

### DIFF
--- a/jquery.motionCaptcha.0.2.js
+++ b/jquery.motionCaptcha.0.2.js
@@ -294,6 +294,10 @@ jQuery.fn.motionCaptcha || (function($) {
 			
 			// Enable the submit button:
 			$submit.prop('disabled', false);
+
+			if ( $.mobile ) {
+				$submit.button('enable');
+			}
 			
 			return;
 		},


### PR DESCRIPTION
While using MotionCAPTCHA and jQuery Mobile, an issue when trying to activate the submit button occurs.

The `disabled` attribute is removed indeed, but jQuery Mobile still blocks it.

This is a fix for that issue
